### PR TITLE
Add option to filter BLE scan operation for devices with supported services

### DIFF
--- a/Sources/LibDCSwift/BLEManager.swift
+++ b/Sources/LibDCSwift/BLEManager.swift
@@ -248,8 +248,10 @@ public class CoreBluetoothManager: NSObject, CoreBluetoothManagerProtocol, Obser
         }
     }
     
-    public func startScanning() {
-        centralManager.scanForPeripherals(withServices: nil, options: nil)
+    public func startScanning(filterUnsupportedPeripherials: Bool = true) {
+        centralManager.scanForPeripherals(
+            withServices: filterUnsupportedPeripherials ? knownSerialServices.map { CBUUID(string: $0.uuid) } : nil,
+            options: nil)
         isScanning = true
     }
     

--- a/Sources/LibDCSwift/BLEManager.swift
+++ b/Sources/LibDCSwift/BLEManager.swift
@@ -248,9 +248,9 @@ public class CoreBluetoothManager: NSObject, CoreBluetoothManagerProtocol, Obser
         }
     }
     
-    public func startScanning(filterUnsupportedPeripherials: Bool = true) {
+    public func startScanning(omitUnsupportedPeripherals: Bool = true) {
         centralManager.scanForPeripherals(
-            withServices: filterUnsupportedPeripherials ? knownSerialServices.map { CBUUID(string: $0.uuid) } : nil,
+            withServices: omitUnsupportedPeripherals ? knownSerialServices.map { CBUUID(string: $0.uuid) } : nil,
             options: nil)
         isScanning = true
     }


### PR DESCRIPTION
This is a very small change, adding the option to filter the bluetooth scan process so that it only detects devices with known serial services (i.e. only supported dive computers) instead of listing all BLE devices nearby.

Added an optional parameter to `startScanning(filterUnsupportedPeripherials: Bool = true)`

If set to true it will pass the list of known serial services to `centralManager.scanForPeripherals(...)` so that only devices with know services are detected.

This removes the burden from the application developer to manually connect to detected devices and check if they  are supported and allows to easily scan for only supported devices.

By default the option is set to true since there seems to be no downside to this and I suspect this would be the most common use case, but it could easily be changed to default to false in case there are any concerns about backwards compatibility.