### PR TITLE
Feature: Expose dive fingerprint

### DIFF
--- a/Sources/LibDCSwift/DiveLogRetriever.swift
+++ b/Sources/LibDCSwift/DiveLogRetriever.swift
@@ -150,7 +150,8 @@ public class DiveLogRetriever {
                 model: modelToUse, 
                 diveNumber: context.logCount,
                 diveData: data,
-                dataSize: Int(size)
+                dataSize: Int(size),
+                fingerprint: fingerprintData
             )
             
             DispatchQueue.main.async {

--- a/Sources/LibDCSwift/Models/DiveData.swift
+++ b/Sources/LibDCSwift/Models/DiveData.swift
@@ -265,7 +265,11 @@ public struct DiveData: Identifiable {
     
     // Decompression data
     public var decoStop: DecoStop?
-    
+
+    // Raw fingerprint bytes identifying the specific dive on the computer,
+    // returned by dc_device_foreach's per-dive callback.
+    public var fingerprint: Data?
+
     public struct Tank {
         public var volume: Double
         public var workingPressure: Double
@@ -411,7 +415,8 @@ public struct DiveData: Identifiable {
         setpoint: Double?,
         ppo2Readings: [(sensor: UInt32, value: Double)],
         cns: Double?,
-        decoStop: DecoStop?
+        decoStop: DecoStop?,
+        fingerprint: Data? = nil
     ) {
         self.number = number
         self.datetime = datetime
@@ -441,5 +446,6 @@ public struct DiveData: Identifiable {
         self.ppo2Readings = ppo2Readings
         self.cns = cns
         self.decoStop = decoStop
+        self.fingerprint = fingerprint
     }
-} 
+}

--- a/Sources/LibDCSwift/Parser/GenericParser.swift
+++ b/Sources/LibDCSwift/Parser/GenericParser.swift
@@ -205,7 +205,8 @@ public class GenericParser {
         diveNumber: Int,
         diveData: UnsafePointer<UInt8>,
         dataSize: Int,
-        context: OpaquePointer? = nil
+        context: OpaquePointer? = nil,
+        fingerprint: Data? = nil
     ) throws -> DiveData {
         var parser: OpaquePointer?
         
@@ -533,7 +534,8 @@ public class GenericParser {
                     time: TimeInterval(deco.time),
                     type: Int(deco.type.rawValue)
                 )
-            }
+            },
+            fingerprint: fingerprint
         )
     }
     


### PR DESCRIPTION
This exposes the fingerprint of the individual dive to the DiveData model.

I have a macOS and iPhone that sync with an api service to store logs.  I would like to pass through a form of the fingerprint to help with duplicate checking.

If it's not something you are interested in adding, no worries.

Example displaying it in a list:
<img width="925" height="359" alt="Screenshot 2026-07-31 at 12 59 59 PM" src="https://github.com/user-attachments/assets/964f5d8c-67a5-42cf-af9c-708684ff7213" />
