### PR TITLE
Keep per-tank pressure for multi-transmitter dives (fixes #41)

### DIFF
--- a/Sources/LibDCSwift/Models/DiveData.swift
+++ b/Sources/LibDCSwift/Models/DiveData.swift
@@ -62,7 +62,8 @@ public struct DiveProfilePoint {
     public let time: TimeInterval
     public let depth: Double
     public let temperature: Double?
-    public let pressure: Double?
+    public let pressure: Double?  // Primary (lowest-index) tank; convenience for single-tank dives
+    public let tankPressures: [Int: Double]  // Live pressure (bar) per tank index; holds every transmitter of the sample
     public let po2: Double?  // Oxygen partial pressure
     public let pn2: Double?  // Nitrogen partial pressure
     public let phe: Double?  // Helium partial pressure
@@ -89,6 +90,7 @@ public struct DiveProfilePoint {
         depth: Double,
         temperature: Double? = nil,
         pressure: Double? = nil,
+        tankPressures: [Int: Double] = [:],
         po2: Double? = nil,
         pn2: Double? = nil,
         phe: Double? = nil,
@@ -108,6 +110,7 @@ public struct DiveProfilePoint {
         self.depth = depth
         self.temperature = temperature
         self.pressure = pressure
+        self.tankPressures = tankPressures
         self.po2 = po2
         self.pn2 = pn2
         self.phe = phe

--- a/Sources/LibDCSwift/Models/SampleData.swift
+++ b/Sources/LibDCSwift/Models/SampleData.swift
@@ -20,6 +20,21 @@ public struct SampleData {
     
     // Tank pressure data
     var pressure: [(tank: Int, value: Double)] = []  // Tank pressure readings
+
+    // Live pressure per tank index. libdivecomputer fires DC_SAMPLE_PRESSURE once
+    // per transmitter, so one sample can carry readings for several tanks; keeping
+    // a single value dropped every tank but the last (deepsealabs/libdc-swift#41).
+    var currentTankPressures: [Int: Double] = [:]
+
+    // Lowest-index tank's live pressure, for the single-value convenience field.
+    var primaryTankPressure: Double? {
+        currentTankPressures.min(by: { $0.key < $1.key })?.value
+    }
+
+    mutating func recordTankPressure(tank: Int, value: Double) {
+        currentTankPressures[tank] = value
+        pressure.append((tank: tank, value: value))
+    }
     
     // Profile data
     var profile: [DiveProfilePoint] = []  // Detailed dive profile

--- a/Sources/LibDCSwift/Parser/GenericParser.swift
+++ b/Sources/LibDCSwift/Parser/GenericParser.swift
@@ -121,7 +121,8 @@ public class GenericParser {
                 time: data.time,
                 depth: data.depth,
                 temperature: data.temperature,
-                pressure: data.pressure.last?.value,
+                pressure: data.primaryTankPressure,
+                tankPressures: data.currentTankPressures,
                 po2: data.ppo2.last?.value,
                 ndl: ndl,
                 decoStop: decoStop,
@@ -257,10 +258,13 @@ public class GenericParser {
                 wrapper.data.maxDepth = max(wrapper.data.maxDepth, value.depth)
                 
             case DC_SAMPLE_PRESSURE:
-                wrapper.data.pressure.append((
+                // Fired once per transmitter within a sample; record each against
+                // its own tank so multi-transmitter dives (sidemount, CCR) keep
+                // every curve instead of only the last (deepsealabs/libdc-swift#41).
+                wrapper.data.recordTankPressure(
                     tank: Int(value.pressure.tank),
                     value: value.pressure.value
-                ))
+                )
                 
             case DC_SAMPLE_TEMPERATURE:
                 wrapper.data.temperature = value.temperature

--- a/Tests/LibDCSwiftTests/TankPressureTests.swift
+++ b/Tests/LibDCSwiftTests/TankPressureTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import LibDCSwift
+
+/// Regression coverage for deepsealabs/libdc-swift#41: libdivecomputer fires
+/// DC_SAMPLE_PRESSURE once per transmitter, so a single sample can carry a
+/// reading for several tanks. The parser must keep each against its own tank
+/// index rather than collapsing to one value.
+final class TankPressureTests: XCTestCase {
+
+    func testMultipleTransmittersInOneSampleAllSurvive() {
+        var sample = SampleData()
+
+        // Two transmitters report within the same sample window (sidemount / CCR).
+        sample.recordTankPressure(tank: 0, value: 200.0)
+        sample.recordTankPressure(tank: 1, value: 210.0)
+
+        XCTAssertEqual(sample.currentTankPressures[0], 200.0)
+        XCTAssertEqual(sample.currentTankPressures[1], 210.0,
+                       "Second transmitter must not be dropped by the first")
+        XCTAssertEqual(sample.currentTankPressures.count, 2)
+    }
+
+    func testLaterReadingUpdatesItsOwnTankOnly() {
+        var sample = SampleData()
+        sample.recordTankPressure(tank: 0, value: 200.0)
+        sample.recordTankPressure(tank: 1, value: 210.0)
+
+        // Next window: tank 0 drops, tank 1 unchanged / not re-reported.
+        sample.recordTankPressure(tank: 0, value: 190.0)
+
+        XCTAssertEqual(sample.currentTankPressures[0], 190.0)
+        XCTAssertEqual(sample.currentTankPressures[1], 210.0,
+                       "Updating one tank must not disturb the other")
+    }
+
+    func testPrimaryTankPressureIsLowestIndex() {
+        var sample = SampleData()
+        sample.recordTankPressure(tank: 1, value: 210.0)
+        sample.recordTankPressure(tank: 0, value: 200.0)
+
+        XCTAssertEqual(sample.primaryTankPressure, 200.0,
+                       "Convenience pressure should be the lowest-index tank regardless of arrival order")
+    }
+
+    func testPrimaryTankPressureNilWhenNoReadings() {
+        let sample = SampleData()
+        XCTAssertNil(sample.primaryTankPressure)
+    }
+
+    func testSingleTankBehavesLikeBefore() {
+        var sample = SampleData()
+        sample.recordTankPressure(tank: 0, value: 180.0)
+
+        XCTAssertEqual(sample.primaryTankPressure, 180.0)
+        XCTAssertEqual(sample.currentTankPressures, [0: 180.0])
+    }
+
+    func testProfilePointCarriesEveryTank() {
+        let point = DiveProfilePoint(
+            time: 60,
+            depth: 22,
+            pressure: 200.0,
+            tankPressures: [0: 200.0, 1: 210.0]
+        )
+
+        XCTAssertEqual(point.pressure, 200.0)
+        XCTAssertEqual(point.tankPressures[0], 200.0)
+        XCTAssertEqual(point.tankPressures[1], 210.0)
+    }
+}


### PR DESCRIPTION
## What

For dives with more than one tank pressure transmitter (sidemount with two AI pods, or CCR with O2 + diluent), the parser kept only **one tank's pressure per profile sample** — the second transmitter's curve was silently dropped.

libdivecomputer fires `DC_SAMPLE_PRESSURE` **once per transmitter** within a sample, each carrying a `pressure.tank` index. The parser read the index at collection time but then collapsed it: `addProfilePoint()` snapshotted only `data.pressure.last?.value`, and `DiveProfilePoint.pressure` is a single `Double?` that structurally can't hold two tanks.

## Change

- `SampleData` accumulates live pressure per tank index (`currentTankPressures`) via a new `recordTankPressure(tank:value:)`, with a `primaryTankPressure` convenience (lowest-index tank).
- `DiveProfilePoint` gains `tankPressures: [Int: Double]` alongside the existing `pressure`. `pressure` now resolves to the primary (lowest-index) tank, so **single-tank consumers are unchanged** (identical value to before).
- The `DC_SAMPLE_PRESSURE` callback records each transmitter against its own tank; `addProfilePoint()` snapshots the full per-tank map into the point.

The dive-level `DiveData.tankPressure: [Double]` flat output is left as-is for source compatibility; per-tank data now lives on the profile points where consumers should read it.

Mirrors the fix Submersion applied to the same underlying library (their issue #1223).

## Scope note

The Suunto Nautic path (`SuuntoNauticExplorer`) already preserves per-tank pressure via its own `tankProfile` — this bug was specific to the generic `DC_SAMPLE_PRESSURE` path used by Shearwater et al.

## Test

`TankPressureTests` covers the retention invariant: two transmitters in one sample both survive, per-tank updates don't disturb siblings, `primaryTankPressure` is lowest-index, and single-tank behaves as before. `swift test`: 24/24 pass (18 existing + 6 new), no regressions.

A real two-transmitter fixture (Shearwater Perdix/Teric sidemount or a Petrel CCR raw dive) would strengthen this into an end-to-end parser test — we have no in-house dual-transmitter capture (all our captures are single-AI Suunto Nautic), so that's a follow-up. Submersion used a Petrel-3 CCR fixture for exactly this.

Fixes #41