### PR TITLE
Nautic: skip empty-read dives and withhold fingerprint

### DIFF
--- a/Sources/LibDCSwift/DiveLogRetriever.swift
+++ b/Sources/LibDCSwift/DiveLogRetriever.swift
@@ -22,6 +22,14 @@ public class DiveLogRetriever {
         var storedFingerprint: Data?
         var isCompleted: Bool = false
         var fingerprintMatched: Bool = false  // Track if we stopped due to fingerprint match
+        /// Dives that parsed to an empty/degenerate record (no profile
+        /// samples, ~0 duration) and were skipped. On the Suunto NG family
+        /// this is the signature of a contended BLE stream (the official
+        /// Suunto app still holding the link): enumeration succeeds but the
+        /// data payload comes back empty. Used at completion to withhold the
+        /// fingerprint (so a clean retry re-downloads) and to signal the
+        /// empty-read outcome instead of a false "no new dives".
+        var emptyReadCount: Int = 0
         /// When false, a "download only new" toggle-off — skip loading/comparing
         /// against the stored fingerprint entirely so a full history re-download
         /// isn't cut short by the fingerprint match early-return below.
@@ -38,6 +46,14 @@ public class DiveLogRetriever {
             self.bluetoothManager = bluetoothManager
             self.useFingerprint = useFingerprint
         }
+    }
+
+    /// A parsed record with no profile samples AND no meaningful duration is
+    /// an empty read, not a real dive. Both conditions are required so a
+    /// genuine ultra-short dive -- which still carries samples -- is never
+    /// dropped. See `CallbackContext.emptyReadCount`.
+    static func isEmptyRead(_ dive: DiveData) -> Bool {
+        dive.profile.isEmpty && dive.divetime <= 1
     }
 
     private static let diveCallbackClosure: @convention(c) (
@@ -166,14 +182,28 @@ public class DiveLogRetriever {
                 fallbackDate: fallbackDate
             )
             
+            // A record with no profile samples AND no duration isn't a real
+            // dive -- it's an empty read. Skip it: don't surface a phantom
+            // dive, don't count it as new, and (via emptyReadCount at
+            // completion) don't advance the fingerprint. logCount still
+            // advances so dive numbers stay unique. Both conditions are
+            // required so a genuine ultra-short dive (which still carries
+            // samples) is never dropped.
+            if isEmptyRead(diveData) {
+                logWarning("⚠️ Skipping empty/degenerate dive #\(context.logCount) (no samples, 0 duration)")
+                context.emptyReadCount += 1
+                context.logCount += 1
+                return 1
+            }
+
             DispatchQueue.main.async {
                 context.viewModel.appendDives([diveData])
                 context.viewModel.updateProgress(count: context.logCount)
             }
-            
+
             context.hasNewDives = true
             context.logCount += 1
-            return 1  
+            return 1
         } catch {
             logError("❌ Failed to parse dive #\(context.logCount): \(error)")
             return 1 
@@ -360,9 +390,9 @@ public class DiveLogRetriever {
 
                 DispatchQueue.main.async {
                     // Determine the outcome of the download
-                    let downloadSucceeded: Bool
-                    let shouldSaveFingerprint: Bool
-                    
+                    var downloadSucceeded: Bool
+                    var shouldSaveFingerprint: Bool
+
                     switch enumStatus {
                     case DC_STATUS_SUCCESS:
                         // Normal successful completion
@@ -397,9 +427,27 @@ public class DiveLogRetriever {
                         shouldSaveFingerprint = false
                     }
                     
+                    // Empty reads override the status-derived outcome: if any
+                    // dive came back empty this session, never advance the
+                    // fingerprint (so a clean retry re-downloads rather than
+                    // reporting "no new dives" forever). When *every* read was
+                    // empty and nothing real arrived, it's a soft failure the
+                    // caller should surface (e.g. "close the Suunto app"),
+                    // distinct from a genuine no-new-dives.
+                    let emptyReadOnly = context.emptyReadCount > 0 && !context.hasNewDives
+                    if context.emptyReadCount > 0 {
+                        shouldSaveFingerprint = false
+                        if emptyReadOnly { downloadSucceeded = false }
+                    }
+
                     // Handle the outcome
                     if !downloadSucceeded {
-                        viewModel.setDetailedError("Download incomplete - DC_STATUS error code: \(enumStatus)", status: enumStatus)
+                        if emptyReadOnly {
+                            logWarning("⚠️ Download returned only empty reads (\(context.emptyReadCount)) — likely BLE contention (official app holding the link)")
+                            viewModel.updateProgress(.emptyRead)
+                        } else {
+                            viewModel.setDetailedError("Download incomplete - DC_STATUS error code: \(enumStatus)", status: enumStatus)
+                        }
                         completion(false)
                     } else {
                         // Download completed successfully

--- a/Sources/LibDCSwift/ViewModels/DiveDataViewModel.swift
+++ b/Sources/LibDCSwift/ViewModels/DiveDataViewModel.swift
@@ -153,7 +153,13 @@ public class DiveDataViewModel: ObservableObject {
         case cancelled
         case failed(_ message: String)
         case noNewDives
-        
+        /// Every dive this session parsed to an empty record (no samples, no
+        /// duration) and was skipped -- typically a contended BLE stream on
+        /// the Suunto NG family (the official Suunto app still holds the
+        /// link). Distinct from noNewDives: the fingerprint was NOT advanced,
+        /// so the caller should prompt a retry rather than report success.
+        case emptyRead
+
         public var description: String {
             switch self {
             case .notStarted: return "Not started"
@@ -162,6 +168,7 @@ public class DiveDataViewModel: ObservableObject {
             case .cancelled: return "Download cancelled"
             case .failed(let error): return "Error: \(error)"
             case .noNewDives: return "No new dives found"
+            case .emptyRead: return "Download returned no dive data"
             }
         }
         
@@ -174,6 +181,8 @@ public class DiveDataViewModel: ObservableObject {
             case (.cancelled, .cancelled):
                 return true
             case (.noNewDives, .noNewDives):
+                return true
+            case (.emptyRead, .emptyRead):
                 return true
             case let (.inProgress(count1), .inProgress(count2)):
                 return count1 == count2

--- a/Tests/LibDCSwiftTests/EmptyReadTests.swift
+++ b/Tests/LibDCSwiftTests/EmptyReadTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import LibDCSwift
+
+/// Coverage for the empty-read guard (deepsealabs/currents DEE-44).
+///
+/// On the Suunto NG family a contended BLE stream (the official Suunto app
+/// still holding the link) lets enumeration succeed while the data payload
+/// comes back empty. libdivecomputer still hands us a record, which parses
+/// into a degenerate `DiveData` (no profile samples, ~0 duration). Persisting
+/// it produces a phantom dive (max depth ~1.4 m, 0 min, flat pressure) and,
+/// worse, burns the fingerprint so a later clean retry reports "no new dives"
+/// forever. `DiveLogRetriever.isEmptyRead` is the gate that classifies these.
+final class EmptyReadTests: XCTestCase {
+
+    /// Builds a DiveData varying only what the guard inspects.
+    private func makeDive(profile: [DiveProfilePoint], divetime: TimeInterval) -> DiveData {
+        DiveData(
+            number: 1,
+            datetime: Date(timeIntervalSince1970: 1_787_000_000),
+            maxDepth: profile.map(\.depth).max() ?? 1.4,
+            avgDepth: 0,
+            divetime: divetime,
+            temperature: 21,
+            profile: profile,
+            tankPressure: [],
+            gasMix: nil,
+            gasMixCount: nil,
+            gasMixes: nil,
+            salinity: nil,
+            atmospheric: nil,
+            surfaceTemperature: nil,
+            minTemperature: nil,
+            maxTemperature: nil,
+            tankCount: nil,
+            tanks: nil,
+            diveMode: nil,
+            decoModel: nil,
+            location: nil,
+            rbt: nil,
+            heartbeat: nil,
+            bearing: nil,
+            setpoint: nil,
+            ppo2Readings: [],
+            cns: nil,
+            decoStop: nil
+        )
+    }
+
+    private func sample(_ time: TimeInterval, _ depth: Double) -> DiveProfilePoint {
+        DiveProfilePoint(time: time, depth: depth)
+    }
+
+    func testNoSamplesAndZeroDurationIsEmptyRead() {
+        // Jeroen's exact case: a "dive" with no profile and no time.
+        let dive = makeDive(profile: [], divetime: 0)
+        XCTAssertTrue(DiveLogRetriever.isEmptyRead(dive))
+    }
+
+    func testRealDiveWithSamplesIsNotEmptyRead() {
+        let profile = (0...30).map { sample(TimeInterval($0 * 2), Double($0) * 0.1) }
+        let dive = makeDive(profile: profile, divetime: 60)
+        XCTAssertFalse(DiveLogRetriever.isEmptyRead(dive))
+    }
+
+    func testGenuineUltraShortDiveIsNotDropped() {
+        // A very short real dive still carries samples -- the guard requires
+        // BOTH conditions precisely so this is never mistaken for empty.
+        let profile = [sample(0, 0.5), sample(1, 1.2)]
+        let dive = makeDive(profile: profile, divetime: 1)
+        XCTAssertFalse(DiveLogRetriever.isEmptyRead(dive))
+    }
+
+    func testSamplesButZeroReportedDurationIsNotEmptyRead() {
+        // Has real samples; only requiring both conditions keeps this dive.
+        let profile = [sample(0, 0.5), sample(2, 3.0), sample(4, 1.0)]
+        let dive = makeDive(profile: profile, divetime: 0)
+        XCTAssertFalse(DiveLogRetriever.isEmptyRead(dive))
+    }
+
+    func testEmptyReadProgressIsDistinctFromNoNewDives() {
+        XCTAssertNotEqual(
+            DiveDataViewModel.DownloadProgress.emptyRead,
+            DiveDataViewModel.DownloadProgress.noNewDives
+        )
+        XCTAssertEqual(
+            DiveDataViewModel.DownloadProgress.emptyRead,
+            DiveDataViewModel.DownloadProgress.emptyRead
+        )
+    }
+}


### PR DESCRIPTION
## Problem

A contended BLE stream on the Suunto NG family (the official Suunto app still holding the single BLE link) lets enumeration succeed while the data payload comes back empty. libdivecomputer still emits a record, which parses into a degenerate `DiveData` (no profile samples, ~0 duration). Downstream (Currents) this surfaces a phantom dive — max depth ~1.4 m, 0 min, flat pressure — and, worse, the fingerprint gets saved, so a later clean retry reports "no new dives" forever.

Reported by a real user on the shipped app; see deepsealabs/currents DEE-44. Related to the Nautic/Ocean work in #29.

## Fix

- `DiveLogRetriever` now classifies a parsed record via `isEmptyRead` (no profile samples **AND** ~0 duration — both required so a genuine ultra-short dive, which still carries samples, is never dropped) and skips it: it isn't surfaced as a dive and isn't counted as new.
- At completion, whenever any empty read occurred the fingerprint is **withheld**, so a clean retry re-downloads instead of being cut short.
- When *every* read was empty and nothing real arrived, a distinct `DownloadProgress.emptyRead` outcome is signalled (via `completion(false)`) instead of a false `noNewDives`, so the caller can prompt the user (e.g. "close the Suunto app") rather than silently reporting success.

## Tests

New `EmptyReadTests` (5 cases) covering the exact empty case, real dives, the genuine-ultra-short guard, samples-but-zero-duration, and `.emptyRead` vs `.noNewDives`. Full suite (29) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pyeZodmZ5cTDJysokDsCb